### PR TITLE
Explicitly specify Sass and CoffeeScript files in `Guardfile`

### DIFF
--- a/lib/guard/livereload/templates/Guardfile
+++ b/lib/guard/livereload/templates/Guardfile
@@ -4,5 +4,5 @@ guard 'livereload' do
   watch(%r{public/.+\.(css|js|html)})
   watch(%r{config/locales/.+\.yml})
   # Rails Assets Pipeline
-  watch(%r{(app|vendor)(/assets/\w+/(.+\.(css|js|html|png|jpg))).*}) { |m| "/assets/#{m[3]}" }
+  watch(%r{(app|vendor)(/assets/\w+/(.+\.(css|scss|sass|js|coffee|html|png|jpg))).*}) { |m| "/assets/#{m[3]}" }
 end


### PR DESCRIPTION
Recently @rails generators changed the way they name the Asset Pipeline files (around `4.2.x`, maybe `4.x`):

`resources.css.scss` -> `resources.scss`
`resources.css.sass` -> `resources.sass`
`resources.js.coffee` -> `resources.coffee`

So this ought to support new behavior out-of-the-box.